### PR TITLE
Fix inability to add new page to menu

### DIFF
--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -952,20 +952,6 @@ class Admin extends Plugin {
 	 * @param int $post_id The post ID for the collection being saved.
 	 */
 	public function save_post_collection_cb( $post_id ): void {
-		// Make sure the function exists, in case a custom post
-		// type is being updated from another screen or using
-		// WordPress BackboneJS API.
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return;
-		}
-
-		$screen = get_current_screen();
-
-		// Only hook into save_post for our wm_collection post type.
-		if ( is_object( $screen ) && 'wm_collection' !== $screen->post_type ) {
-			return;
-		}
-
 		$collection_wp_obj = get_post( $post_id );
 		$query             = $collection_wp_obj->post_title;
 		$response          = $this->widen->search_assets( $query, 0, 100, true );

--- a/lib/Plugin.php
+++ b/lib/Plugin.php
@@ -113,7 +113,7 @@ class Plugin {
 		$this->loader->add_filter( 'post_row_actions', $plugin_admin, 'remove_collections_quick_edit', 10, 2 );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'remove_collections_submit_box' );
 		$this->loader->add_action( 'add_meta_boxes', $plugin_admin, 'register_collection_meta_boxes' );
-		$this->loader->add_action( 'save_post', $plugin_admin, 'save_post_collection_cb' );
+		$this->loader->add_action( 'save_post_wm_collection', $plugin_admin, 'save_post_collection_cb' );
 
 		// Register custom image sizes with WordPress.
 		$this->loader->add_action( 'after_setup_theme', $plugin_admin, 'register_image_sizes' );


### PR DESCRIPTION
This pull request fixes https://github.com/masonitedoors/widen-media/issues/30.

It appears that WP Menu API fires `save_post` when attempting to add a new page to a menu. This action was slipping through the checks at the top of our callback which was throwing the error and ultimately preventing a new menu item from being created.

By instead using https://developer.wordpress.org/reference/hooks/save_post_post-post_type/, we are able to remove the previous checks that were meant to scope the save action to just the `wm_collection` post type.